### PR TITLE
Bug fixes in SearchFilter.py, more descriptive error when semantic search returns 0 results

### DIFF
--- a/modules/SearchFilter.py
+++ b/modules/SearchFilter.py
@@ -128,9 +128,9 @@ class SearchFilter:
         if len(semantic) > 0:
             if len(results) == 0:
                 limit = int(self.ui.semanticBox.text())
-                self.setStatus(f"No gadgets found matching semantic criteria (searched {limit} gadgets)", True)
+                self.setStatus(f"No gadgets found matching semantic criteria (searched {limit} gadgets).", True)
             else:
-                self.setStatus(f"Semantic search completed: {len(results)} gadgets found")
+                self.setStatus(f"Semantic search completed.")
 
         # Build pool and update rendering
         if len(results) == 0:

--- a/modules/SearchFilter.py
+++ b/modules/SearchFilter.py
@@ -36,22 +36,22 @@ class SearchFilter:
 
         # Parse disasm option
         if 'disasm' in query:
-            if 'disasm.' in query:
-                query = query.replace('disasm.','disasm.str.')
+            if 'disasm.' in query and 'disasm.str.' not in query:
+                query = query.replace('disasm.', 'disasm.str.')
             gaveAttr = True
 
         # Parse loc option
         if 'loc' in query:
-            if 'loc.' in query:
-                query = query.replace('loc.','loc.str.')
+            if 'loc.' in query and 'loc.str.' not in query:
+                query = query.replace('loc.', 'loc.str.')
             gaveAttr = True
 
         # Parse bytes option
         if 'bytes' in query:
-            if 'bytes.' in query:
-                query = query.replace('bytes.','bytes.str.')
-            query = query.replace('0x','')
-            query = query.replace('\\x','')
+            if 'bytes.' in query and 'bytes.str.' not in query:
+                query = query.replace('bytes.', 'bytes.str.')
+            query = query.replace('0x', '')
+            query = query.replace('\\x', '')
             gaveAttr = True
 
         # .has() -> .contains()
@@ -109,10 +109,9 @@ class SearchFilter:
         if len(semantic) > 0:
             self.__semanticRegs = semantic
             if not run_progress_dialog("Performing semantic search",True,self.semantic):
-                status = "Semantic search on "
-                for reg in semantic:
-                    status += reg + ", "
-                self.setStatus(status[:-2] + " canceled",True)
+                status = "Semantic search canceled for registers: "
+                status += ", ".join(semantic)
+                self.setStatus(status, True)
 
         # Default search behaviour
         if not gaveAttr and len(semantic) == 0:
@@ -128,9 +127,10 @@ class SearchFilter:
 
         if len(semantic) > 0:
             if len(results) == 0:
-                self.setStatus("Semantic search failed",True)
+                limit = int(self.ui.semanticBox.text())
+                self.setStatus(f"No gadgets found matching semantic criteria (searched {limit} gadgets)", True)
             else:
-                self.setStatus("Semantic search completed")
+                self.setStatus(f"Semantic search completed: {len(results)} gadgets found")
 
         # Build pool and update rendering
         if len(results) == 0:


### PR DESCRIPTION
RopView currently has a bug that yields the following error when attempting to run a search:

```
[RopView.Notify] 'StringMethods' object has no attribute 'str'
```

In Searchfilter.py, this is because the code is trying to add `.str.` to column accessors that already have it, and this results in something like `disasm.str.str.contains()` which causes Pandas to throw the error. The problem lies in the `query` method, where it replaces `disasm.` with `disasm.str.` without checking to see if `.str.` is already present.

To fix this error, the query method has been updated to check to see if `.str.` is already present though the addition of an `and 'disasm.str.'` in the `not in query` conditional check.

This pull request also replaces the non-descript "Semantic search failed" error with a more descriptive error: "No gadgets found matching semantic search criteria (searched X gadgets)".